### PR TITLE
Bug fix repeated state 2

### DIFF
--- a/examples/LEDandButton_1/LEDandButton_1.ino
+++ b/examples/LEDandButton_1/LEDandButton_1.ino
@@ -27,10 +27,10 @@ void setup() {
 
 void loop() {
   // update debounce state
-  int updateB = button.run();
+  button.run();
 
-  // check if run() up0 {dated the debounce state
-  if (updateB ==  true
+  // check if run() updated the debounce state
+  if (button.ready() == true) {
     // get debounced input state and light LED accordingly
     if (button.getDebounceState() == DEBOUNCE_PRESSED) {
       // button pressed

--- a/examples/LEDandButton_2/LEDandButton_2.ino
+++ b/examples/LEDandButton_2/LEDandButton_2.ino
@@ -30,10 +30,10 @@ void setup() {
 
 void loop() {
   // update debounce state
-  int updateB = button.run();
+  button.run();
 
   // check if run() updated the debounce state
-  if (updateB == true) {
+  if (button.ready() == true) {
     // get debounced input state and light LED accordingly
     if (button.getDebounceState() == DEBOUNCE_PRESSED) {
       // button pressed

--- a/src/DebounceNoInt.cpp
+++ b/src/DebounceNoInt.cpp
@@ -122,7 +122,7 @@ bool DebounceNoInt::run() {
 	Returns true if the debounce state was updated by a previous call to run().
 	Return false if the debounce state was NOT updated by a previous call to run().
 */
-DebounceNoInt::ready() {
+bool DebounceNoInt::ready() {
 	return state_updated;
 }
 

--- a/src/DebounceNoInt.cpp
+++ b/src/DebounceNoInt.cpp
@@ -104,11 +104,26 @@ bool DebounceNoInt::run() {
 		}
 
 		ret = 1;
+		// set ready flag
+		state_updated = true;
 	} else {
 		ret = 0;
+		// reset ready flag
+		state_updated = false;
 	}
 
 	return ret;
+}
+
+/*
+	ready
+
+	Used to check to see if the debounce state is up to date and valid for use.
+	Returns true if the debounce state was updated by a previous call to run().
+	Return false if the debounce state was NOT updated by a previous call to run().
+*/
+DebounceNoInt::ready() {
+	return state_updated;
 }
 
 /*
@@ -120,17 +135,4 @@ bool DebounceNoInt::run() {
 */
 uint8_t DebounceNoInt::getDebounceState() {
 	return debounce_state;
-}
-
-/*
-	runAndGetDebounceState
-
-	Equivalent to calling run the immediately calling getDebounceState. Returns the current debounced input state,
-	or the previous state if the state was not updated by run.
-*/
-uint8_t DebounceNoInt::runAndGetDebounceState() {
-	run();
-	uint8_t state = getDebounceState();
-
-	return state;
 }

--- a/src/DebounceNoInt.h
+++ b/src/DebounceNoInt.h
@@ -18,8 +18,8 @@ class DebounceNoInt {
 		virtual ~DebounceNoInt();
 		void begin();
 		bool run();
+		bool ready();
 		uint8_t getDebounceState();
-		uint8_t runAndGetDebounceState();
 	
 	private:
 		int _pin;
@@ -31,6 +31,7 @@ class DebounceNoInt {
 		uint8_t debounce_state = DEBOUNCE_NOISE;	// safe default state
 		unsigned long last_debounce_micros = 0;
 		unsigned long curr_debounce_micros = 0;
+		bool state_updated = false;		// ready flag
 };
 
 #endif


### PR DESCRIPTION
Fixed the repeated states issue by adding a flag that is set and reset by run(), and a getter method to check the flag. The return value of run() already provided this flag implicitly, but this adds an explicit method to check to the flag status.